### PR TITLE
API endpoints via /api prefix

### DIFF
--- a/src/server/main.js
+++ b/src/server/main.js
@@ -1,37 +1,38 @@
-//impport dependencies
+// import dependencies
 const express = require("express");
 const ViteExpress = require("vite-express");
 const mongoose = require("mongoose");
 const bodyParser = require("body-parser");
 
-//import routers:
+// import routers:
 const Router = require("./routes.js");
 
-//init app
+// init app
 const app = express();
 
-//make sure to get json objects from post requests data
+// config
+const WEB_SERVER_PORT = 3000;
+const MONGODB_DOMAIN = "127.0.0.1";
+const MONGODB_SERVER_PORT = 27017;
+
+// make sure to get json objects from post requests data
 app.use(express.json());
 app.use(bodyParser.json());
 
+// using the imports in the application
+// when url is localhost:3000/, the router is called
+app.use("/api", Router);
 
-//using the imports in the application
-//when url is localhost:3000/ , the router is called
-app.use("/", Router);
-
-//debuging route-----------------------------
-app.get("/hello", (req, res) => {
-  res.send("Hello Vite + React!");
-});
-//-----------------------------------------
-
-//connect to local mongo DB. (needs to be installed and running)
-mongoose.set("strictQuery", false);
-main().catch((err) => console.log(err));
-async function main() {
-  await mongoose.connect("mongodb://127.0.0.1:27017");
+// connect to local mongo DB function.
+async function connectdb() {
+  await mongoose.connect(`mongodb://${MONGODB_DOMAIN}:${MONGODB_SERVER_PORT}`);
 }
 
-ViteExpress.listen(app, 3000, () =>
-  console.log("Server is listening on port 3000...")
+// connect to mongodb (needs to be installed and running)
+mongoose.set("strictQuery", false);
+connectdb().catch((err) => console.log(err));
+
+// start web-server
+ViteExpress.listen(app, WEB_SERVER_PORT, () =>
+  console.log(`Server is listening on port ${WEB_SERVER_PORT}...`)
 );

--- a/src/server/models/todo.js
+++ b/src/server/models/todo.js
@@ -3,10 +3,10 @@ const mongoose = require("mongoose");
 const Schema = mongoose.Schema;
 
 const TodoSchema = new Schema({
-    description: {type: String, requires:true, maxLength: 160},
-    deadline: {type:String, requires:true},
-    progress: {type:Number, require:true, min:0, max:100, default:0}
-})
+  description: { type: String, requires: true, maxLength: 160 },
+  deadline: { type: String, requires: true },
+  progress: { type: Number, require: true, min: 0, max: 100, default: 0 },
+});
 
 //maybe add virtual for url?
 

--- a/src/server/routes.js
+++ b/src/server/routes.js
@@ -1,69 +1,65 @@
 const express = require("express");
 const asyncHandler = require("express-async-handler");
-const bodyParser = require("body-parser");
 
 const router = express.Router();
 const TodoModel = require("./models/todo");
 
-
-//might be better to handle erros TODOO
+// TODO: might be better to handle errors
 /*
 router.get("/Todos", asyncHandler( async (req,res) => {
     const allTodos = await TodoModel.find({}).exec();
     res.send(allTodos);
     })
-);*/
+);
+*/
 
-//---------------------------------------
-//http requests header should have >> Content-Type: application/json
-router.get("/Todos", async function (req,res) {
-    const allTodos = await TodoModel.find({}).exec();
-    res.send(allTodos);
+// ---------------------------------------
+// http requests header should have >> Content-Type: application/json
+router.get("/Todos", async function (req, res) {
+  const allTodos = await TodoModel.find({}).exec();
+  res.send(allTodos);
 });
 
-router.post("/Todo/create", async function (req,res) {
-    const newtodo = new TodoModel({
-        description: req.body.description,
-        deadline: req.body.deadline,
-        progress: req.body.progress
-    });
+router.post("/Todo/create", async function (req, res) {
+  const newtodo = new TodoModel({
+    description: req.body.description,
+    deadline: req.body.deadline,
+    progress: req.body.progress,
+  });
 
-    await newtodo.save();
-    res.send(newtodo);
+  await newtodo.save();
+  res.send(newtodo);
 });
 
-router.put("/Todo/edit", async function (req,res) {
+router.put("/Todo/edit", async function (req, res) {
+  // find Todo in db
+  const todo = await TodoModel.findById(req.body.id).exec();
+  if (todo === null) {
+    const err = new Error("Todo not found");
+    err.status = 404;
+    return next(err);
+  }
 
-    //find Todo in db
-    const todo = await TodoModel.findById(req.body.id).exec();
-    if(todo === null){
-        const err = new Error("Todo not found");
-        err.status = 404;
-        return next(err);
-    }
+  // update the Todo
+  todo.description = req.body.description;
+  todo.deadline = req.body.deadline;
+  todo.progress = req.body.progress;
+  await todo.save();
 
-    //update the Todo
-    todo.description = req.body.description;
-    todo.deadline = req.body.deadline;
-    todo.progress = req.body.progress;
-    await todo.save();
-
-    res.send(todo)
+  res.send(todo);
 });
 
-router.delete("/Todo/delete", async function (req,res) {
-    //find and delete Todo
-    const deleted = await TodoModel.findByIdAndDelete(req.body.id).exec();
+router.delete("/Todo/delete", async function (req, res) {
+  // find and delete Todo
+  const deleted = await TodoModel.findByIdAndDelete(req.body.id).exec();
 
-    if(deleted === null){
-        const err = new Error("Todo not found");
-        err.status = 404;
-        return next(err);
-    }
+  if (deleted === null) {
+    const err = new Error("Todo not found");
+    err.status = 404;
+    return next(err);
+  }
 
-    res.status(200).send();
+  res.status(200).send();
 });
-
-
 
 module.exports = router;


### PR DESCRIPTION
- All API endpoints can now be accessed via the /api prefix, e.g. "localhost:3000/_**api**_/todos"
- fixed some formatting and removed some unused imports